### PR TITLE
Opt for guard instead of force unwraps

### DIFF
--- a/JacquardToolkit/JSConstants.swift
+++ b/JacquardToolkit/JSConstants.swift
@@ -20,13 +20,13 @@ struct JSConstants {
     
     struct JSStrings {
         
-        struct CentralManagerState {
-            static let unknown = "Bluetooth Manager's state is unknown"
-            static let resetting = "Bluetooth Manager's state is resetting"
-            static let unsupporting = "Bluetooth Manager's state is unsupporting"
-            static let unauthorized = "Bluetooth Manager's state is unauthorized"
-            static let poweredOn = "Bluetooth Manager's state is powered on"
-            static let poweredOff = "Bluetooth Manager's state is powered off"
+        enum CentralManagerState: String {
+            case unknown = "Bluetooth Manager's state is unknown"
+            case resetting = "Bluetooth Manager's state is resetting"
+            case unsupporting = "Bluetooth Manager's state is unsupporting"
+            case unauthorized = "Bluetooth Manager's state is unauthorized"
+            case poweredOn = "Bluetooth Manager's state is powered on"
+            case poweredOff = "Bluetooth Manager's state is powered off"
         }
         
         struct ErrorMessages {

--- a/JacquardToolkit/JSQRCodeScannerView.swift
+++ b/JacquardToolkit/JSQRCodeScannerView.swift
@@ -16,24 +16,24 @@ public class JSQRCodeScannerView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
         
-        let captureDevice = AVCaptureDevice.default(for: .video)
-        
-        do {
-            let input = try AVCaptureDeviceInput(device: captureDevice!)
-            session.addInput(input)
-        } catch {
-            print("Error")
+        if let captureDevice = AVCaptureDevice.default(for: .video) {
+            do {
+                let input = try AVCaptureDeviceInput(device: captureDevice)
+                session.addInput(input)
+            } catch {
+                print("Error")
+            }
+            
+            let output = AVCaptureMetadataOutput()
+            session.addOutput(output)
+            
+            output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+            output.metadataObjectTypes = [.qr]
+            
+            video = AVCaptureVideoPreviewLayer(session: session)
+            video.frame = self.layer.bounds
+            self.layer.addSublayer(video)
         }
-        
-        let output = AVCaptureMetadataOutput()
-        session.addOutput(output)
-        
-        output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
-        output.metadataObjectTypes = [.qr]
-        
-        video = AVCaptureVideoPreviewLayer(session: session)
-        video.frame = self.layer.bounds
-        self.layer.addSublayer(video)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -56,7 +56,7 @@ extension JSQRCodeScannerView: AVCaptureMetadataOutputObjectsDelegate {
     public func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
         if let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject {
             if object.type == .qr {
-                JacquardService.shared.updateJacketIDString(jacketIDString: object.stringValue!)
+                JacquardService.shared.updateJacketIDString(jacketIDString: object.stringValue)
                 session.startRunning()
             }
         }


### PR DESCRIPTION
## Changes

- To prevent crashing if methods are not implement switch to optional calling of methods instead of force unwraps
- Switch `CentralManagerState` to an enum
